### PR TITLE
Remove all clippy warnings in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
   pull_request:
 
-env: 
+env:
   CARGO_TERM_COLOR: always
 
 jobs:
@@ -25,17 +25,30 @@ jobs:
     name: rustfmt
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v1
-      with:
-        fetch-depth: 1
-    - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
-        profile: minimal
-        components: rustfmt
-    - name: Check formatting
-      run: |
-        cargo fmt -- --check
+      - name: Checkout repository
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
+          components: rustfmt
+      - name: Check formatting
+        run: |
+          cargo fmt -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
+          components: clippy
+      - run: cargo clippy --tests -- -D warnings

--- a/src/test.rs
+++ b/src/test.rs
@@ -43,11 +43,11 @@ sitemap: https://example.com/sitemap.xml";
             Err(_) => panic!("Crawl-Delay not correctly retrieved"),
         };
         // Test float (good)
-        let good_text = "    crawl-delay  : 3.14";
+        let good_text = "    crawl-delay  : 3.16";
         match robots_txt_parse(good_text.as_bytes()) {
             Ok((_, lines)) => {
                 assert_eq!(lines.len(), 1);
-                assert_eq!(lines[0], CrawlDelay(Some(3.14)));
+                assert_eq!(lines[0], CrawlDelay(Some(3.16)));
             }
             Err(_) => panic!("Crawl-Delay not correctly retrieved"),
         };
@@ -375,12 +375,12 @@ sitemap: https://example.com/sitemap.xml";
         // For the first two it'd be an allowed input and the latter is ignored
         for statement in statements {
             let mut crash: Vec<u8> =
-                [statement.as_bytes(), &vec!['A' as u8; 4096]].concat();
+                [statement.as_bytes(), &vec![b'A'; 4096]].concat();
             // Add wildcards (*) and an end match ($) to trigger full regex mode
             // Compilation doesn't fail when using the two shortcut modes
             crash.extend(b"*$");
-            crash[10] = '*' as u8;
-            crash[30] = '*' as u8;
+            crash[10] = b'*';
+            crash[30] = b'*';
             let r = Robot::new("BobBot", &crash);
             assert!(r.is_err());
         }
@@ -391,7 +391,7 @@ sitemap: https://example.com/sitemap.xml";
 
     #[test]
     fn test_url_prepare_relative() {
-        for (url, path) in vec![
+        for (url, path) in [
             ("https://example.com/foo/bar/baz.html", "/foo/bar/baz.html"),
             ("https://example.com/", "/"),
             ("https://example.com/path", "/path"),
@@ -653,7 +653,7 @@ sitemap: https://example.com/sitemap.xml";
         diasllow: /e
         disallaw: /f\n";
         let r = Robot::new("FooBot", text.as_bytes()).unwrap();
-        for path in vec!["/a", "/b", "/c", "/d", "/e", "/f"] {
+        for path in ["/a", "/b", "/c", "/d", "/e", "/f"] {
             assert!(!r.allowed(path));
         }
     }
@@ -809,7 +809,7 @@ sitemap: https://example.com/sitemap.xml";
         AlLoW: /x/
         dIsAlLoW: /";
 
-        for bot in vec!["FooBot", "BarBot", "BazBot"] {
+        for bot in ["FooBot", "BarBot", "BazBot"] {
             let r = Robot::new(bot, txt.as_bytes()).unwrap();
             assert!(r.allowed("http://foo.bar/x/y"));
             assert!(!r.allowed("http://foo.bar/a/b"));
@@ -984,7 +984,7 @@ sitemap: https://example.com/sitemap.xml";
 
     #[test]
     fn test_google_documentation_checks() {
-        for r in vec!["/fish", "/fish*"] {
+        for r in ["/fish", "/fish*"] {
             let txt = format!(
                 "user-agent: FooBot
             disallow: /
@@ -1097,7 +1097,7 @@ sitemap: https://example.com/sitemap.xml";
             
             
             Disallow: /";
-            let txt = txt.replace("\n", line_ending);
+            let txt = txt.replace('\n', line_ending);
             let (buffer, lines) = robots_txt_parse(txt.as_bytes()).unwrap();
             assert!(buffer.is_empty());
             assert_eq!(lines.len(), 6);
@@ -1147,11 +1147,9 @@ sitemap: https://example.com/sitemap.xml";
 
     #[test]
     fn test_google_utf8_bom_is_skipped() {
-        for bom in vec![
-            b"\xef\xbb\xbf".to_vec(),
-            b"\xef\xbb".to_vec(),
-            b"\xef".to_vec(),
-        ] {
+        for bom in
+            [b"\xef\xbb\xbf".to_vec(), b"\xef\xbb".to_vec(), b"\xef".to_vec()]
+        {
             let txt = b"User-Agent: foo\nAllow: /AnyValue\n".to_vec();
             let txt = [&bom[..], &txt[..]].concat();
             let (buffer, lines) = robots_txt_parse(&txt).unwrap();
@@ -1230,7 +1228,7 @@ sitemap: https://example.com/sitemap.xml";
         // https://github.com/servo/rust-url/issues/149
         // "the algorithm specified at https://url.spec.whatwg.org/#path-state ..."
         // "leaves existing percent-encoded sequences unchanged"
-        for (start, end) in vec![
+        for (start, end) in [
             ("http://www.example.com", "/"),
             ("/a/b/c", "/a/b/c"),
             ("/á", "/%C3%A1"),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -41,19 +41,15 @@ mod tests {
         assert!(r.allowed("https://www.reddit.com/"));
         assert!(r.allowed("https://www.reddit.com/r/rust/"));
         assert!(r.allowed("https://www.reddit.com/posts/2020/"));
-        assert!(!r.allowed(&format!("https://www.reddit.com/login")));
+        assert!(!r.allowed("https://www.reddit.com/login"));
         // RSS is allowed
-        assert!(r.allowed(&format!("https://www.reddit.com/r/rust/.rss")));
+        assert!(r.allowed("https://www.reddit.com/r/rust/.rss"));
         // Sitemaps are allowed
-        assert!(
-            r.allowed(&format!("https://www.reddit.com/sitemaps/2014.xml"))
-        );
+        assert!(r.allowed("https://www.reddit.com/sitemaps/2014.xml"));
         // JSON, XML, and "?feed=" are forbidden
-        assert!(!r.allowed(&format!("https://www.reddit.com/r/rust/.json")));
-        assert!(!r.allowed(&format!("https://www.reddit.com/r/rust/.xml")));
-        assert!(
-            !r.allowed(&format!("https://www.reddit.com/r/rust/?feed=simd"))
-        );
+        assert!(!r.allowed("https://www.reddit.com/r/rust/.json"));
+        assert!(!r.allowed("https://www.reddit.com/r/rust/.xml"));
+        assert!(!r.allowed("https://www.reddit.com/r/rust/?feed=simd"));
     }
 
     #[test]


### PR DESCRIPTION
Hi 🙂 
This PR aims at removing the warnings emitted by clippy when running it against the test modules, using `cargo clippy --tests`. There were a number of usless uses of `format!` and `vec!` allocations in the tests.

```
error: useless use of `format!`
  --> tests/integration_test.rs:44:29
   |
44 |         assert!(!r.allowed(&format!("https://www.reddit.com/login")));
   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `"https://www.reddit.com/login".to_string()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_format
   = note: `-D clippy::useless-format` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::useless_format)]`
   ```
   
These warnings are not shown in the VS Code UI by default, because the default check command is `cargo check`, but they start to appear once we change the check command to the more advanced linter `clippy`, like so

```js
// In settings.json
{"rust-analyzer.check.command": "clippy"}
```

I think it might also be a good idea to add a `clippy` step to the CI workflow, but I haven't included it in this PR.

Cheers 🙂 