### PR TITLE
Added multi-agent (aliased) robot support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -349,6 +349,14 @@ impl Robot {
     /// If there are difficulties parsing, which should be rare as the parser is quite
     /// forgiving, then an [InvalidRobots](Error::InvalidRobots) error is returned.
     pub fn new(agent: &str, txt: &[u8]) -> Result<Self, anyhow::Error> {
+        Robot::with_aliases(&[agent], txt)
+    }
+
+    /// Todo(liera); uwu
+    pub fn with_aliases(
+        agent_aliases: &[&str],
+        txt: &[u8],
+    ) -> Result<Self, anyhow::Error> {
         // Replace '\x00' with '\n'
         // This shouldn't be necessary but some websites are strange ...
         let txt = txt
@@ -367,8 +375,11 @@ impl Robot {
         };
 
         // All agents are case insensitive in `robots.txt`
-        let agent = agent.to_lowercase();
-        let mut agent = agent.as_str();
+        let mut agents: Vec<String> = Vec::with_capacity(agent_aliases.len());
+
+        for agent in agent_aliases.iter() {
+            agents.push(agent.to_lowercase());
+        }
 
         // Collect all sitemaps
         // Why? "The sitemap field isn't tied to any specific user agent and may be followed by all crawlers"
@@ -393,13 +404,13 @@ impl Robot {
 
         // Check if our crawler is explicitly referenced, otherwise we're catch all agent ("*")
         let references_our_bot = lines.iter().any(|x| match x {
-            Line::UserAgent(ua) => {
+            Line::UserAgent(ua) => agents.iter().any(|agent| {
                 agent.as_bytes() == ua.as_bstr().to_ascii_lowercase()
-            }
+            }),
             _ => false,
         });
         if !references_our_bot {
-            agent = "*";
+            agents = vec!["*".to_string()];
         }
 
         // Collect only the lines relevant to this user agent
@@ -426,7 +437,9 @@ impl Robot {
                     Line::UserAgent(ua) => ua.as_bstr(),
                     _ => unreachable!(),
                 };
-                if agent.as_bytes() == ua.as_bstr().to_ascii_lowercase() {
+                if agents.iter().any(|agent| {
+                    agent.as_bytes() == ua.as_bstr().to_ascii_lowercase()
+                }) {
                     capturing = true;
                 }
                 idx += 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -352,7 +352,21 @@ impl Robot {
         Robot::with_aliases(&[agent], txt)
     }
 
-    /// Todo(liera); uwu
+    /// Construct a new Robot object specifically processed for all the given
+    /// user agents as a single robot. Just like <Robot::new> it extracts all
+    /// relevant rules from the `robots.txt` addressed to any of the aliases
+    /// as if it is all one robot and stores them internally. It defaults to
+    /// `*` entries when none of the agents names are found case-insensitively
+    /// within the `robots.txt`.
+    ///
+    /// Using robot aliases can be useful when your robot changed its name and
+    /// you want to stay backwards compatible with what people already have in
+    /// their `robots.txt` for your robot without having to parse the file
+    /// multiple times.
+    ///
+    /// # Errors
+    /// While it is forgiving parsing difficulties with given text can
+    /// result in a returned [InvalidRobots](Error::InvalidRobots) error.
     pub fn with_aliases(
         agent_aliases: &[&str],
         txt: &[u8],
@@ -378,7 +392,9 @@ impl Robot {
         let mut agents: Vec<String> = Vec::with_capacity(agent_aliases.len());
 
         for agent in agent_aliases.iter() {
-            agents.push(agent.to_lowercase());
+            if agent.len() > 0 {
+                agents.push(agent.to_lowercase());
+            }
         }
 
         // Collect all sitemaps

--- a/src/test.rs
+++ b/src/test.rs
@@ -301,11 +301,22 @@ sitemap: https://example.com/sitemap.xml";
     fn test_robot_alias_empty() {
         let txt = "user-agent: *
         Disallow: /
+        user-agent:
+        user-agent: 
         ";
-        let agents = [""];
-        let robot = Robot::with_aliases(&agents, txt.as_bytes()).unwrap();
+        let variants_empty_agent = [vec![], vec![""]];
 
-        assert_eq!(robot.allowed("/allow/"), false);
+        for agent in variants_empty_agent {
+            let robot = Robot::with_aliases(&agent.as_slice(), txt.as_bytes())
+                .unwrap();
+
+            assert_eq!(
+                robot.allowed("/"),
+                false,
+                "Empty agent {:?} should still map to '*'",
+                agent
+            );
+        }
     }
 
     /// From Common Crawl burn test

--- a/src/test.rs
+++ b/src/test.rs
@@ -279,6 +279,35 @@ sitemap: https://example.com/sitemap.xml";
         assert!(s.contains("https://example.com/sitemap.xml"));
     }
 
+    #[test]
+    fn test_robot_alias_multiple() {
+        let txt = "user-agent: lovely_bot
+        Allow: /allow/
+        Disallow: /but not this/
+        User-agent: shinyNewName
+        Allow: /but not this/except this one/
+        Disallow:/allow/except_this
+        ";
+        let agents = ["lovely_bot", "shinyNewName"];
+        let robot = Robot::with_aliases(&agents, txt.as_bytes()).unwrap();
+
+        assert!(robot.allowed("/allow/"));
+        assert!(robot.allowed("/but not this/except this one/"));
+        assert_eq!(robot.allowed("/but not this/"), false);
+        assert_eq!(robot.allowed("/allow/except_this"), false);
+    }
+
+    #[test]
+    fn test_robot_alias_empty() {
+        let txt = "user-agent: *
+        Disallow: /
+        ";
+        let agents = [""];
+        let robot = Robot::with_aliases(&agents, txt.as_bytes()).unwrap();
+
+        assert_eq!(robot.allowed("/allow/"), false);
+    }
+
     /// From Common Crawl burn test
     //
 


### PR DESCRIPTION
Adds support for the robots who get renamed in there lifespan. This allows parsing for the new name while being able to keep backwards compatibility with existing names people already have for it in their `robots.txt` file without parsing multiple times.

Usage:
```rs
use texting_robots::Robot;

let robot_names = ["Ferris", "Alice"];
let robot = Robot::with_aliases(&robot_names, b"Disallow: /secret")
    .unwrap();
assert_eq!(robot.allowed("/secret"), false);
```
Instead of the previous heavier version which needed to parse multiple times for the same single check:
```rs
use texting_robots::Robot;

let robot_names = ["Ferris", "Alice"];
for name in robot_names {
    let robot = Robot::new(name, b"Disallow: /secret").unwrap();
    assert_eq!(robot.allowed("/secret"), false);
}
```